### PR TITLE
bounds check in Gather operation

### DIFF
--- a/caffe2/operators/utility_ops.h
+++ b/caffe2/operators/utility_ops.h
@@ -1320,7 +1320,11 @@ class GatherOp : public Operator<Context> {
     auto out = static_cast<char*>(output->raw_mutable_data(data.meta()));
 
     for (int i = 0; i < N; ++i) {
-      auto src = src_base + idxs[i] * block_bytesize;
+      auto idx = idxs[i];
+      CAFFE_ENFORCE(
+          0 <= idx && idx < data.dim(0),
+          "INDICES element is out of DATA bounds");
+      auto src = src_base + idx * block_bytesize;
       context_.template CopyItems<Context, Context>(
           data.meta(), block_size, src, out + block_bytesize * i);
     }


### PR DESCRIPTION
Summary: Currently Gather doesn't check if the provided indices are in the correct range. Adding a check makes issues easier to debug

Reviewed By: dzhulgakov

Differential Revision: D4277170

fbshipit-source-id: dc744b6a229aaf72af8336a417f0f79c97dbdc77